### PR TITLE
fix the output directory so that the pipeline works

### DIFF
--- a/config/typescript-axios-v0.yaml
+++ b/config/typescript-axios-v0.yaml
@@ -1,5 +1,5 @@
 generatorName: typescript-axios
-outputDir: mitxonline-clients/src/typescript/mitxonline-api-axios/src/v0
+outputDir: mitxonline-api-clients/src/typescript/mitxonline-api-axios/src/v0
 inputSpec: mitxonline/openapi/specs/v0.yaml
 ignoreFileOverride: mitxonline-api-clients/.openapi-generator-ignore
 additionalProperties:


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/7217

### Description (What does it do?)
This PR corrects the `outputDir` setting in the config to point at `mitxonline-api-clients` instead of `mitxonline-clients`, because that's where the pipeline that publishes the library expects the output artifacts to be.

### How can this be tested?
This needs to be tested by running the pipeline in production and making sure it picks up the artficts in the `publish` job