### PR TITLE
fix versioning by setting current_version in bumpver

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.bumpver]
-current_version = "2024.1.1"
+current_version = "2025.4.30"
 version_pattern = "YYYY.MM.DD[.INC0]"
 commit = false
 tag = false
@@ -24,6 +24,7 @@ push = false
 [tool.bumpver.file_patterns]
 "pyproject.toml" = [
     '^version = "{version}"',
+    '^current_version = "{version}"',
 ]
 "src/typescript/mitxonline-api-axios/package.json" = [
     '"version": "{version}"',


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/7257

### Description (What does it do?)
This PR fixes versioning of the API client library by setting `current_version` in the `bumpver` configuration in `pyproject.toml`. This is needed for the version to be properly incremented.

### How can this be tested?
This change needs to be merged before the pipeline is run again to test it.
