### PR TITLE
Update package.json to include exports for the v2 APIs

### DIFF
--- a/src/typescript/mitxonline-api-axios/package.json
+++ b/src/typescript/mitxonline-api-axios/package.json
@@ -29,6 +29,11 @@
       "import": "./dist/esm/v1/index.js",
       "require": "./dist/cjs/v1/index.js",
       "default": "./dist/esm/v1/index.js"
+    },
+    "./v2": {
+      "import": "./dist/esm/v2/index.js",
+      "require": "./dist/cjs/v2/index.js",
+      "default": "./dist/esm/v2/index.js"
     }
   },
   "license": "BSD-3",


### PR DESCRIPTION
### What are the relevant tickets?

Related to https://github.com/mitodl/mitxonline/pull/2832

### Description (What does it do?)

We separate out the MITx Online APIs into `v0`, `v1`, and `v2`. The `package.json` here didn't have exports for v2 in it, though. So, this PR adds it.

### How can this be tested?

If you build it manually and install it somewhere, you should be able to import stuff out of the v2 API. 
