### PR TITLE
append suffix to mitxonline branch name

### DIFF
--- a/scripts/generate_branch_client.sh
+++ b/scripts/generate_branch_client.sh
@@ -3,6 +3,11 @@
 # Generate API clients from a specific branch of the mitxonline repo.
 # Usage: ./generate_branch_client <branch-name>
 #
+# Each invocation publishes to a unique branch named
+#   <branch-name>-client-<short-source-rev>
+# so re-runs never collide with each other on push. The install URL pins
+# by commit SHA, so consumers don't depend on the branch name itself.
+#
 set -eo pipefail
 
 BRANCH_NAME="${1:-}"
@@ -18,55 +23,54 @@ if ! git check-ref-format --branch "$BRANCH_NAME" >/dev/null 2>&1; then
 fi
 
 REPO_ROOT="$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel)"
-CLIENT_BRANCH="${BRANCH_NAME}-client"
+TS_CLIENT_DIR="$REPO_ROOT/src/typescript/mitxonline-api-axios"
+MITXONLINE_REPO="https://github.com/mitodl/mitxonline.git"
 
-# Step 1: Sync local '$CLIENT_BRANCH' with origin so re-runs are always fast-forwards.
-echo "Fetching origin/$CLIENT_BRANCH (ok if it doesn't exist yet)..."
-git -C "$REPO_ROOT" fetch origin "$CLIENT_BRANCH" || true
+# Step 1: Resolve the upstream rev so the client branch name pins to it.
+SOURCE_REV="$(git ls-remote "$MITXONLINE_REPO" "$BRANCH_NAME" | head -n1 | awk '{print $1}')"
+if [ -z "$SOURCE_REV" ]; then
+  echo "Error: branch '$BRANCH_NAME' not found in $MITXONLINE_REPO."
+  exit 1
+fi
+SHORT_SOURCE_REV="${SOURCE_REV:0:7}"
+CLIENT_BRANCH="${BRANCH_NAME}-client-${SHORT_SOURCE_REV}"
 
+# Always end the script back on the branch the user started from.
+ORIGINAL_BRANCH="$(git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD)"
+trap 'git -C "$REPO_ROOT" checkout "$ORIGINAL_BRANCH" >/dev/null 2>&1 || true' EXIT
+
+# Step 2: If this rev was already published, point at the existing commit and exit.
+git -C "$REPO_ROOT" fetch origin "$CLIENT_BRANCH" 2>/dev/null || true
 if git -C "$REPO_ROOT" show-ref --verify --quiet "refs/remotes/origin/$CLIENT_BRANCH"; then
-  echo "Syncing local '$CLIENT_BRANCH' to 'origin/$CLIENT_BRANCH'..."
-  if git -C "$REPO_ROOT" show-ref --verify --quiet "refs/heads/$CLIENT_BRANCH"; then
-    git -C "$REPO_ROOT" checkout "$CLIENT_BRANCH"
-  else
-    git -C "$REPO_ROOT" checkout -b "$CLIENT_BRANCH" "origin/$CLIENT_BRANCH"
-  fi
-  git -C "$REPO_ROOT" reset --hard "origin/$CLIENT_BRANCH"
-else
-  CURRENT_BRANCH="$(git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD)"
-  if [ "$CURRENT_BRANCH" = "$CLIENT_BRANCH" ]; then
-    echo "Already on branch '$CLIENT_BRANCH'."
-  else
-    if git -C "$REPO_ROOT" show-ref --verify --quiet "refs/heads/$CLIENT_BRANCH"; then
-      echo "Switching to existing branch '$CLIENT_BRANCH'..."
-      git -C "$REPO_ROOT" checkout "$CLIENT_BRANCH"
-    else
-      echo "Creating and switching to new branch '$CLIENT_BRANCH'..."
-      git -C "$REPO_ROOT" checkout -b "$CLIENT_BRANCH"
-    fi
-  fi
+  EXISTING_SHA="$(git -C "$REPO_ROOT" rev-parse "origin/$CLIENT_BRANCH")"
+  echo "Source rev $SHORT_SOURCE_REV already published as branch '$CLIENT_BRANCH'."
+  echo ""
+  echo "  yarn up @mitodl/mitxonline-api-axios@https://github.com/mitodl/mitxonline-api-clients/raw/${EXISTING_SHA}/src/typescript/mitxonline-api-axios/package.tgz"
+  echo ""
+  exit 0
 fi
 
-# Step 2: Run local-generate.sh against the specified branch of repo X
-echo ""
-echo "Generating clients from branch '$BRANCH_NAME' of mitxonline..."
+# Step 3: Generate using the calling branch's tooling.
+echo "Generating clients from branch '$BRANCH_NAME' (rev $SHORT_SOURCE_REV) of mitxonline..."
 BRANCH_NAME="$BRANCH_NAME" "$REPO_ROOT/scripts/local-generate.sh"
 
-# Step 3 & 4: Install deps and pack the TypeScript client
-TS_CLIENT_DIR="$REPO_ROOT/src/typescript/mitxonline-api-axios"
 echo ""
 echo "Running yarn install and yarn pack in $TS_CLIENT_DIR..."
 (cd "$TS_CLIENT_DIR" && yarn install && yarn pack)
 
-# Commit the generated client files (if any changed)
+# Step 4: Create the publish branch from current HEAD and commit the generated dir.
+echo ""
+echo "Creating branch '$CLIENT_BRANCH'..."
+git -C "$REPO_ROOT" checkout -B "$CLIENT_BRANCH"
+
 git -C "$REPO_ROOT" add src/typescript/mitxonline-api-axios/
 if git -C "$REPO_ROOT" diff --cached --quiet -- src/typescript/mitxonline-api-axios/; then
-  echo "No changes to commit."
-else
-  git -C "$REPO_ROOT" commit -m "build(client): Generate client for branch $BRANCH_NAME" -- src/typescript/mitxonline-api-axios/
+  echo "No generated changes — nothing to commit."
+  exit 0
 fi
+git -C "$REPO_ROOT" commit -m "build(client): Generate client for $BRANCH_NAME @ $SHORT_SOURCE_REV" -- src/typescript/mitxonline-api-axios/
 
-# Step 5: Push branch (with confirmation)
+# Step 5: Push (with confirmation).
 echo ""
 read -r -p "Push branch '$CLIENT_BRANCH' to origin? [y/N] " confirm
 if [[ "$confirm" =~ ^[Yy]$ ]]; then

--- a/scripts/generate_branch_client.sh
+++ b/scripts/generate_branch_client.sh
@@ -12,20 +12,38 @@ if [ -z "$BRANCH_NAME" ]; then
   exit 1
 fi
 
+if ! git check-ref-format --branch "$BRANCH_NAME" >/dev/null 2>&1; then
+  echo "Error: '$BRANCH_NAME' is not a valid git branch name."
+  exit 1
+fi
+
 REPO_ROOT="$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel)"
 CLIENT_BRANCH="${BRANCH_NAME}-client"
 
-# Step 1: Checkout branch in this repo (create if needed)
-CURRENT_BRANCH="$(git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD)"
-if [ "$CURRENT_BRANCH" = "$CLIENT_BRANCH" ]; then
-  echo "Already on branch '$CLIENT_BRANCH'."
-else
+# Step 1: Sync local '$CLIENT_BRANCH' with origin so re-runs are always fast-forwards.
+echo "Fetching origin/$CLIENT_BRANCH (ok if it doesn't exist yet)..."
+git -C "$REPO_ROOT" fetch origin "$CLIENT_BRANCH" || true
+
+if git -C "$REPO_ROOT" show-ref --verify --quiet "refs/remotes/origin/$CLIENT_BRANCH"; then
+  echo "Syncing local '$CLIENT_BRANCH' to 'origin/$CLIENT_BRANCH'..."
   if git -C "$REPO_ROOT" show-ref --verify --quiet "refs/heads/$CLIENT_BRANCH"; then
-    echo "Switching to existing branch '$CLIENT_BRANCH'..."
     git -C "$REPO_ROOT" checkout "$CLIENT_BRANCH"
   else
-    echo "Creating and switching to new branch '$CLIENT_BRANCH'..."
-    git -C "$REPO_ROOT" checkout -b "$CLIENT_BRANCH"
+    git -C "$REPO_ROOT" checkout -b "$CLIENT_BRANCH" "origin/$CLIENT_BRANCH"
+  fi
+  git -C "$REPO_ROOT" reset --hard "origin/$CLIENT_BRANCH"
+else
+  CURRENT_BRANCH="$(git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD)"
+  if [ "$CURRENT_BRANCH" = "$CLIENT_BRANCH" ]; then
+    echo "Already on branch '$CLIENT_BRANCH'."
+  else
+    if git -C "$REPO_ROOT" show-ref --verify --quiet "refs/heads/$CLIENT_BRANCH"; then
+      echo "Switching to existing branch '$CLIENT_BRANCH'..."
+      git -C "$REPO_ROOT" checkout "$CLIENT_BRANCH"
+    else
+      echo "Creating and switching to new branch '$CLIENT_BRANCH'..."
+      git -C "$REPO_ROOT" checkout -b "$CLIENT_BRANCH"
+    fi
   fi
 fi
 
@@ -42,10 +60,10 @@ echo "Running yarn install and yarn pack in $TS_CLIENT_DIR..."
 
 # Commit the generated client files (if any changed)
 git -C "$REPO_ROOT" add src/typescript/mitxonline-api-axios/
-if git -C "$REPO_ROOT" diff --cached --quiet; then
+if git -C "$REPO_ROOT" diff --cached --quiet -- src/typescript/mitxonline-api-axios/; then
   echo "No changes to commit."
 else
-  git -C "$REPO_ROOT" commit -m "build(client): Generate client for branch $BRANCH_NAME"
+  git -C "$REPO_ROOT" commit -m "build(client): Generate client for branch $BRANCH_NAME" -- src/typescript/mitxonline-api-axios/
 fi
 
 # Step 5: Push branch (with confirmation)
@@ -54,13 +72,13 @@ read -r -p "Push branch '$CLIENT_BRANCH' to origin? [y/N] " confirm
 if [[ "$confirm" =~ ^[Yy]$ ]]; then
   git -C "$REPO_ROOT" push -u origin "$CLIENT_BRANCH"
   echo "Branch '$CLIENT_BRANCH' pushed to origin."
-else
-  echo "Skipped push."
-fi
 
-COMMIT_SHA="$(git -C "$REPO_ROOT" rev-parse HEAD)"
-echo ""
-echo "Branch client now installable from github via"
-echo ""
-echo "  yarn up @mitodl/mitxonline-api-axios@https://github.com/mitodl/mitxonline-api-clients/raw/${COMMIT_SHA}/src/typescript/mitxonline-api-axios/package.tgz"
-echo ""
+  COMMIT_SHA="$(git -C "$REPO_ROOT" rev-parse HEAD)"
+  echo ""
+  echo "Branch client now installable from github via"
+  echo ""
+  echo "  yarn up @mitodl/mitxonline-api-axios@https://github.com/mitodl/mitxonline-api-clients/raw/${COMMIT_SHA}/src/typescript/mitxonline-api-axios/package.tgz"
+  echo ""
+else
+  echo "Skipped push. Re-run and accept the push prompt to make the client installable from github."
+fi

--- a/scripts/generate_branch_client.sh
+++ b/scripts/generate_branch_client.sh
@@ -13,18 +13,19 @@ if [ -z "$BRANCH_NAME" ]; then
 fi
 
 REPO_ROOT="$(git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel)"
+CLIENT_BRANCH="${BRANCH_NAME}-client"
 
 # Step 1: Checkout branch in this repo (create if needed)
 CURRENT_BRANCH="$(git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD)"
-if [ "$CURRENT_BRANCH" = "$BRANCH_NAME" ]; then
-  echo "Already on branch '$BRANCH_NAME'."
+if [ "$CURRENT_BRANCH" = "$CLIENT_BRANCH" ]; then
+  echo "Already on branch '$CLIENT_BRANCH'."
 else
-  if git -C "$REPO_ROOT" show-ref --verify --quiet "refs/heads/$BRANCH_NAME"; then
-    echo "Switching to existing branch '$BRANCH_NAME'..."
-    git -C "$REPO_ROOT" checkout "$BRANCH_NAME"
+  if git -C "$REPO_ROOT" show-ref --verify --quiet "refs/heads/$CLIENT_BRANCH"; then
+    echo "Switching to existing branch '$CLIENT_BRANCH'..."
+    git -C "$REPO_ROOT" checkout "$CLIENT_BRANCH"
   else
-    echo "Creating and switching to new branch '$BRANCH_NAME'..."
-    git -C "$REPO_ROOT" checkout -b "$BRANCH_NAME"
+    echo "Creating and switching to new branch '$CLIENT_BRANCH'..."
+    git -C "$REPO_ROOT" checkout -b "$CLIENT_BRANCH"
   fi
 fi
 
@@ -39,22 +40,27 @@ echo ""
 echo "Running yarn install and yarn pack in $TS_CLIENT_DIR..."
 (cd "$TS_CLIENT_DIR" && yarn install && yarn pack)
 
-# Commit the generated client files
+# Commit the generated client files (if any changed)
 git -C "$REPO_ROOT" add src/typescript/mitxonline-api-axios/
-git -C "$REPO_ROOT" commit -m "build(client): Generate client for branch $BRANCH_NAME"
+if git -C "$REPO_ROOT" diff --cached --quiet; then
+  echo "No changes to commit."
+else
+  git -C "$REPO_ROOT" commit -m "build(client): Generate client for branch $BRANCH_NAME"
+fi
 
 # Step 5: Push branch (with confirmation)
 echo ""
-read -r -p "Push branch '$BRANCH_NAME' to origin? [y/N] " confirm
+read -r -p "Push branch '$CLIENT_BRANCH' to origin? [y/N] " confirm
 if [[ "$confirm" =~ ^[Yy]$ ]]; then
-  git -C "$REPO_ROOT" push -u origin "$BRANCH_NAME"
-  echo "Branch '$BRANCH_NAME' pushed to origin."
+  git -C "$REPO_ROOT" push -u origin "$CLIENT_BRANCH"
+  echo "Branch '$CLIENT_BRANCH' pushed to origin."
 else
   echo "Skipped push."
 fi
 
+COMMIT_SHA="$(git -C "$REPO_ROOT" rev-parse HEAD)"
 echo ""
 echo "Branch client now installable from github via"
 echo ""
-echo "  yarn up @mitodl/mitxonline-api-axios@https://github.com/mitodl/mitxonline-api-clients/raw/refs/heads/${BRANCH_NAME}/src/typescript/mitxonline-api-axios/package.tgz"
+echo "  yarn up @mitodl/mitxonline-api-axios@https://github.com/mitodl/mitxonline-api-clients/raw/${COMMIT_SHA}/src/typescript/mitxonline-api-axios/package.tgz"
 echo ""


### PR DESCRIPTION
### What are the relevant tickets?
None

### Description (What does it do?)
Updates `./scripts/generate_branch_client.sh` to append a suffix to the branch name

b/c as-is this would have let you overwrite main, which was not great. (Github probably wouldve prevented it... I'm not an admin on this repo, so i can't check branch protection rules.)

### How can this be tested?
1. Run `./scripts/generate_branch_client.sh main` locally
2. when prompted, push main-client up
3. run the yarn-install in your learn repo
